### PR TITLE
Use combined pool + order book

### DIFF
--- a/projects/muesliswap/index.js
+++ b/projects/muesliswap/index.js
@@ -44,7 +44,7 @@ async function adaTvl(){
         const totalSell = totalAmountOtherToken * topPrice
         totalAda += totalBuy + totalSell
     }))
-    const orderbooksv2 = (await fetchURL("https://orderbookv2.muesliswap.com/all-orderbooks")).data
+    const orderbooksv2 = (await fetchURL("https://pools.muesliswap.com/all-orderbooks")).data
     await Promise.all(orderbooksv2.map(async orders=>{
         if(orders.fromToken !== "."){
             throw new Error("Tokens paired against something other than ADA")


### PR DESCRIPTION
This uses a different URL to query the MueslISwap order book. This order book is enriched with pseudo orders generated from the hybrid AMM (based on Liquidity Pools) that MuesliSwap features. The combined liquidity in the pseudo orders is equal to the TVL of the liquidity pool that generated it, so it should be fair to simply count this as by the previous approach.

We can also think of using two URLs, one for the raw order book and one for the liquidity pools and then independently sum the results and are open for feedback.

